### PR TITLE
Some languages are not presented

### DIFF
--- a/src/LangList.js
+++ b/src/LangList.js
@@ -69,11 +69,11 @@ async function getProgressList(langs) {
   const issuesMap = fromPairs(
     search.nodes
       .filter(issue => !!issue && issue.repository)
-      .map(issue => [issue.repository.name, issue]),
+      .map(issue => [issue.repository.name.toLowerCase(), issue]),
   )
 
   return langs.map(lang => {
-    const issue = issuesMap[`${lang.code}.reactjs.org`]
+    const issue = issuesMap[`${lang.code.toLowerCase()}.reactjs.org`]
     return issue ? getLangProgress(lang, issue) : null
   }).filter(Boolean)
 }

--- a/src/LangList.js
+++ b/src/LangList.js
@@ -62,7 +62,7 @@ async function getProgressList(langs) {
       headers: {
         authorization: `token ${process.env.REACT_APP_GITHUB_AUTH_TOKEN}`,
       },
-      limit: langs.length + 5, // padding in case of extra issues
+      limit: langs.length + 15, // padding in case of extra issues
     },
   )
   console.log(search.nodes)


### PR DESCRIPTION
## Some languages are not presented

This PR corrects the lack of some languages in the [React Translations Page](https://translations.reactjs.org/). Of the 48 languages, 6 were not presented on the page.

To fix the error, it was necessary two corrections:
- [x] Increase the search limit
- [x] Prevent Case-Sensitive in the `ISSUESMAP` index

**Before the corrections**:

![image](https://user-images.githubusercontent.com/64603070/190325669-748dcb4b-d51f-47cb-8600-eba95b84d32e.png)

**After corrections**:
 
![image](https://user-images.githubusercontent.com/64603070/190325760-0d3ba210-1420-4a4b-8673-826aa104d2ce.png)

@tesseralis Are the corrections valid?